### PR TITLE
feat: 카드 찾기 페이지 UI/UX 개선

### DIFF
--- a/src/components/searching/SearchingSwipeItem.tsx
+++ b/src/components/searching/SearchingSwipeItem.tsx
@@ -27,8 +27,8 @@ function SearchingSwipeItem({ card }: { card: SectorBaseSearchingItem }) {
 
   return (
     <div 
-      className={`w-[300px] h-[570px] flex flex-col items-center rounded-[16px] py-[16px] px-[10px] shadow-find-card cursor-pointer transition-opacity relative ${
-        isLoading ? 'opacity-50' : 'hover:opacity-95'
+      className={`w-[340px] min-h-[570px] flex flex-col items-center rounded-[16px] py-[16px] px-[10px] shadow-xl border border-gray-100 cursor-pointer transition-all duration-300 ease-in-out relative ${
+        isLoading ? 'opacity-50' : 'hover:shadow-2xl hover:scale-[1.03] hover:-translate-y-2 hover:border-blue-200'
       }`}
       onClick={handleCardClick}
     >

--- a/src/pages/searching/Searching.tsx
+++ b/src/pages/searching/Searching.tsx
@@ -4,95 +4,72 @@ import { jobs } from "../../data/jobs";
 import SearchingSwipeItem from "../../components/searching/SearchingSwipeItem";
 import { useNavigate } from "react-router-dom";
 import { useSectorBaseSearching } from "../../hooks/searchingQueries";
-import SearchingTopBarContainer from "../../components/searching/SearchingTopBarContainer";
 
 function Searching() {
-  const [searchText, setSearchText] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("기획/PM");
   const [selectedSkill, setSelectedSkill] = useState<string>("서비스 기획자");
   const [sortOption, setSortOption] = useState<"latest" | "oldest">("latest");
-
   const currentCategory = jobs.find((j) => j.category === selectedCategory);
   const navigate = useNavigate();
 
+  // Use the search hook
   const { data } = useSectorBaseSearching({
     high_sector: selectedCategory,
     low_sector: selectedSkill,
     sort: sortOption,
   });
 
-  const handleSearch = () => {
-    if (searchText.trim()) {
-      setSearchText("");
-    }
-  };
-
   const cardsData = data?.pages.flatMap((page) => page.result.cards);
 
   return (
     <BottomNavContainer>
-      <SearchingTopBarContainer
-        TopBarContent={
-          <div className="w-full bg-ct-white">
-            <div className="w-full ct-center">
-              <div className="w-[340px] h-[48px] flex items-center px-1 border-b border-ct-gray-300">
-                <input
-                  type="text"
-                  placeholder="검색어를 입력해주세요."
-                  className="flex-1 bg-transparent placeholder-ct-gray-200 text-sub2 outline-none"
-                  value={searchText}
-                  onChange={(e) => setSearchText(e.target.value)}
-                  onKeyDown={(e) => e.key === "Enter" && handleSearch()}
-                />
-                <button onClick={handleSearch} className="px-2">
-                  <img src="/assets/feed/searchfeed.svg" alt="검색 아이콘" />
-                </button>
-              </div>
-            </div>
 
-            <div className="h-[118px] py-[20px] z-10 bg-ct-white">
-              <div className="flex h-[36px] px-[15px] overflow-x-scroll whitespace-nowrap scrollbar-hide">
-                {jobs.map((item) => (
-                  <button
-                    key={item.category}
-                    className={`h-[32px] text-h2 tracking-[-0.408px] px-[21px] pb-[10px] ${
-                      selectedCategory === item.category
-                        ? "border-b-[4px] border-ct-gray-300 text-ct-black-300"
-                        : "text-ct-gray-200"
-                    }`}
-                    onClick={() => {
-                      setSelectedCategory(item.category);
-                      const firstSkill = jobs.find(
-                        (j) => j.category === item.category
-                      )?.skills[0];
-                      if (firstSkill) setSelectedSkill(firstSkill);
-                    }}
-                  >
-                    {item.category}
-                  </button>
-                ))}
-              </div>
-
-              <div className="mt-[11px] flex w-full max-w-[401px] px-[15px] overflow-x-scroll whitespace-nowrap scrollbar-hide">
-                {currentCategory?.skills.map((skill) => (
-                  <button
-                    key={skill}
-                    className={`flex-1 text-h2 px-[13px] tracking-[-0.32px] ${
-                      selectedSkill === skill
-                        ? "text-ct-black-300"
-                        : "text-ct-gray-200"
-                    }`}
-                    onClick={() => setSelectedSkill(skill)}
-                  >
-                    {skill}
-                  </button>
-                ))}
-              </div>
-            </div>
+      {/* 검색 필터 영역 - 상단 고정 */}
+      <div className="fixed top-0 left-0 right-0 z-20 bg-ct-white shadow-sm border-b border-ct-gray-100 max-w-md mx-auto">
+        {/* 직군 검색 */}
+        <div className="py-[20px]">
+          <div className="flex h-[36px] px-[15px] overflow-x-scroll whitespace-nowrap scrollbar-hide">
+            {jobs.map((item) => (
+              <button
+                key={item.category}
+                className={`h-[32px] text-h2 tracking-[-0.408px] px-[21px] pb-[10px] ${
+                  selectedCategory === item.category
+                    ? "border-b-[4px] border-ct-gray-300 text-ct-black-300"
+                    : "text-ct-gray-200"
+                }`}
+                onClick={() => {
+                  setSelectedCategory(item.category);
+                  const firstSkill = jobs.find(
+                    (j) => j.category === item.category
+                  )?.skills[0];
+                  if (firstSkill) {
+                    setSelectedSkill(firstSkill);
+                  }
+                }}
+              >
+                {item.category}
+              </button>
+            ))}
           </div>
-        }
-      >
-        <div className="w-full ct-center flex-col">
+          <div className="mt-[11px] flex w-full max-w-[401px] px-[15px] overflow-x-scroll whitespace-nowrap scrollbar-hide">
+            {currentCategory?.skills.map((skill) => (
+              <button
+                key={skill}
+                className={`flex-1 text-h2 px-[13px] tracking-[-0.32px] ${
+                  selectedSkill === skill
+                    ? "text-ct-black-300"
+                    : "text-ct-gray-200"
+                }`}
+                onClick={() => setSelectedSkill(skill)}
+              >
+                {skill}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 최신 순 및 필터 */}
+        <div className="w-full ct-center pb-[15px]">
           <div className="w-[340px] flex justify-between items-center">
             <div className="relative">
               <select
@@ -106,7 +83,6 @@ function Searching() {
                 <option value="oldest">오래된 순</option>
               </select>
             </div>
-
             <div
               className="w-[60px] h-[25px] ct-center bg-ct-main-blue-100 rounded-[5px]"
               onClick={() => navigate("/searching/filter")}
@@ -115,14 +91,20 @@ function Searching() {
               <img src="/assets/searching/filter.svg" alt="필터 아이콘" />
             </div>
           </div>
-
-          <div className="w-full ct-center flex-col mt-[30px] gap-[30px]">
-            {cardsData?.map((card) => (
-              <SearchingSwipeItem key={card.card_id} card={card} />
-            ))}
-          </div>
         </div>
-      </SearchingTopBarContainer>
+      </div>
+
+      {/* 고정 헤더 높이만큼 여백 */}
+      <div className="h-[160px]"></div>
+      
+      <div className="w-full ct-center flex-col">
+        {/* 검색 결과 */}
+        <div className="w-full ct-center flex-col mt-[30px] space-y-[40px] pb-[80px]">
+          {cardsData?.map((card) => (
+            <SearchingSwipeItem key={card.card_id} card={card} />
+          ))}
+        </div>
+      </div>
     </BottomNavContainer>
   );
 }


### PR DESCRIPTION
- 카드 간격 조정하여 겹침 문제 해결 (space-y-[40px])
- SearchingSwipeItem에 강화된 그림자와 호버 효과 추가
- 카드 높이를 min-h-[570px]로 변경하여 콘텐츠 오버플로우 해결
- 카드 너비를 w-[340px]로 확장하여 더 넓은 표시 영역 제공
- 불필요한 검색어 입력 필드 제거
- 필터 영역(카테고리, 정렬, 필터)을 상단에 고정(fixed) 배치
- 고정 헤더 하위 콘텐츠가 가려지지 않도록 여백 추가

## 📌 PR 제목

- feat: 로그인 페이지 구현

## ✅ 작업 내용

- 로그인 UI 구현
- 상태 관리 및 유효성 검사 추가
- 테스트 코드 작성

## 🔍 확인 사항

- [ ] 디자인과 일치하는지 확인
- [ ] 모바일 해상도에서 정상 동작
- [ ] 로그인 실패 시 에러 메시지 확인됨

## 📷 스크린샷

(필요 시 캡처 첨부)

## 💬 기타 논의사항

- 리팩토링은 이후 별도 브랜치에서 진행 예정
